### PR TITLE
Feat/atomic tif creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Each release can have sections: "Added", "Changed", "Deprecated", "Removed", "Fi
 ### Added
 
 - Set up Github actions for formatting, tracking CHANGELOG and testing `geefetch` installation [15652c1](https://github.com/gbelouze/geefetch/commit/15652c1c6bb4ac4415cd23c76437510824addb9c)
+- Tests for band selection [ecab767](https://github.com/gbelouze/geefetch/commit/ecab767270f446c11e72a73d79fe68f2db1791dc)
+
+### Changed
+
+- Downloads are made atomic by first downloading `abc.tif` to `abc.tmp.tif` [d79873f](https://github.com/gbelouze/geefetch/commit/d79873fe5932d7f291673f6da2c3cd55950bfa4e)
+- Already existing downloads are not skipped over if they are corrupted [569c563](https://github.com/gbelouze/geefetch/commit/569c563692d4d6880122ace47f5e81c0af36885a)
 
 ### Fixed
 

--- a/src/geefetch/data/downloadables/collection.py
+++ b/src/geefetch/data/downloadables/collection.py
@@ -68,7 +68,10 @@ class DownloadableGEECollection(DownloadableABC):
         for key in kwargs:
             if key not in ["scale", "progress", "max_tile_size"]:
                 log.warning(f"Argument {key} is ignored.")
-        return self._recursively_download(out, region, crs, bands, format)
+        tmp_out = out.with_suffix(f".tmp.{out.suffix}")
+        tmp_out.unlink(missing_ok=True)
+        self._recursively_download(tmp_out, region, crs, bands, format)
+        tmp_out.replace(out)
 
     def _recursively_download(
         self,

--- a/src/geefetch/data/downloadables/geedim.py
+++ b/src/geefetch/data/downloadables/geedim.py
@@ -41,6 +41,24 @@ class PatchedBaseImage(BaseImage):  # type: ignore[misc]
         progress: Progress | None = None,
         **kwargs: Any,
     ) -> None:
+        filename = Path(filename)
+        tmp_filename = filename.with_suffix(f".tmp.{filename.suffix}")
+        tmp_filename.unlink(missing_ok=True)
+        self._download(
+            tmp_filename, overwrite, num_threads, max_tile_size, max_tile_dim, progress, **kwargs
+        )
+        tmp_filename.replace(filename)
+
+    def _download(
+        self,
+        filename: Path | str,
+        overwrite: bool = False,
+        num_threads: int | None = None,
+        max_tile_size: float | None = None,
+        max_tile_dim: int | None = None,
+        progress: Progress | None = None,
+        **kwargs: Any,
+    ) -> None:
         max_threads = num_threads or min(10, (os.cpu_count() or 1) + 4)
         geedim_log.debug(f"Using {max_threads} threads for download.")
         out_lock = threading.Lock()

--- a/src/geefetch/data/get.py
+++ b/src/geefetch/data/get.py
@@ -18,6 +18,7 @@ from .process import (
     merge_tracked_geojson,
     merge_tracked_parquet,
     tif_is_clean,
+    tif_is_not_corrupted,
     vector_is_clean,
 )
 from .satellites import (
@@ -115,8 +116,13 @@ def download_chip(
     """Download a specific chip of data from the satellite."""
     bands = selected_bands if selected_bands is not None else satellite.default_selected_bands
     if out.exists():
-        log.debug(f"Found feature chip [cyan]{out}[/]. Skipping download.")
-        return out
+        log.debug(f"Found feature chip [cyan]{out}[/]")
+        if not tif_is_not_corrupted(out):
+            log.info(f"File [cyan]{out}[/] is corrupted. Removing it.")
+            out.unlink()
+        else:
+            log.debug(f"File {out} does not seem corrupted. Skipping download.")
+            return out
     data = data_get_lazy(**data_get_kwargs)
 
     try:

--- a/src/geefetch/data/process.py
+++ b/src/geefetch/data/process.py
@@ -26,6 +26,16 @@ __all__ = [
 ]
 
 
+def tif_is_not_corrupted(path: Path) -> bool:
+    """Check that a 'tif' file is not corrupted, i.e. can be open with rasterio."""
+    try:
+        with rio.open(path) as x:
+            x.read(1, window=rio.windows.Window(0, 0, 1, 1))
+    except rio.RasterioIOError:
+        return False
+    return True
+
+
 def tif_is_clean(path: Path) -> bool:
     """Check that a 'tif' file is valid and not full of NODATA."""
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,6 @@ from pathlib import Path
 import pytest
 from omegaconf import DictConfig, OmegaConf
 
-from geefetch.cli.omegaconfig import GeefetchConfig, load
-from geefetch.utils.enums import CompositeMethod
-
 TESTS_DIR = Path(__file__).parent
 GEE_PROJECT_ID_ENV_NAME = "GEEFETCH_GEE_PROJECT_ID"
 
@@ -28,41 +25,6 @@ def gee_project_id() -> str:
         case _ as project_id:
             assert isinstance(project_id, str)
             return project_id
-
-
-@pytest.fixture
-def paris_config_path(raw_paris_config: DictConfig, tmp_path: Path, gee_project_id: str) -> Path:
-    raw_paris_config.data_dir = str(tmp_path)
-    raw_paris_config.satellite_default.gee.ee_project_id = gee_project_id
-
-    conf_path = tmp_path / "config.yaml"
-    conf_path.write_text(OmegaConf.to_yaml(raw_paris_config))
-    return conf_path
-
-
-@pytest.fixture
-def paris_timeseriesconfig_path(
-    raw_paris_config: DictConfig, tmp_path: Path, gee_project_id: str
-) -> Path:
-    raw_paris_config.data_dir = str(tmp_path)
-    raw_paris_config.satellite_default.gee.ee_project_id = gee_project_id
-    raw_paris_config.satellite_default.composite_method = CompositeMethod.TIMESERIES
-
-    conf_path = tmp_path / "config.yaml"
-    conf_path.write_text(OmegaConf.to_yaml(raw_paris_config))
-    return conf_path
-
-
-@pytest.fixture
-def paris_config(paris_config_path: Path) -> GeefetchConfig:
-    return load(paris_config_path)
-
-
-@pytest.fixture
-def paris_timeseries_config(paris_config_path: Path) -> GeefetchConfig:
-    config = load(paris_config_path)
-    config.satellite_default.composite_method = CompositeMethod.TIMESERIES
-    return config
 
 
 # ----

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -13,6 +13,7 @@ from geefetch.cli.download_implementation import (
     download_s2,
 )
 from geefetch.cli.omegaconfig import GeefetchConfig, load
+from geefetch.data.process import tif_is_clean
 from geefetch.utils.enums import CompositeMethod
 
 
@@ -82,6 +83,18 @@ def test_download_timeseries_s1(paris_timeseriesconfig_path: Path):
         "s1_EPSG2154_650000_6860000",
         "S1A_IW_GRDH_1SDV_20200111T174030_20200111T174055_030756_0386DC_869A.tif",
     )
+
+
+def test_download_s1_overwrite_garbage(paris_config_path: Path):
+    conf = load(paris_config_path)
+    downloaded_tif_path = Path(conf.data_dir) / "s1" / "s1_EPSG2154_650000_6860000.tif"
+    downloaded_tif_path.parent.mkdir()
+    downloaded_tif_path.write_text("Garbage content")
+    download_s1(paris_config_path)
+    downloaded_files = list(Path(conf.data_dir).rglob("*.tif"))
+    assert len(downloaded_files) == 1
+    assert downloaded_files[0].parts[-2:] == ("s1", "s1_EPSG2154_650000_6860000.tif")
+    assert tif_is_clean(downloaded_tif_path)
 
 
 def test_select_bands_s1(paris_config_all_s1_bands_path: Path):


### PR DESCRIPTION
This makes the download of a file atomic, in that it either download everything or nothing. This is done by working with an intermediary file, i.e

**Download `abc.tif`**
- Download to `abc.tmp.tif`
- This may download by small chunks if the aoi is too big
- This may fail in the middle of downloading
- If it doesn't, atomically rename `abc.tmp.tif` to `abc.tif`
  
  Moreover, this PR adds the detection of corrupted tif files, understood as files that fail when trying to `rio.open` them.
  It also adds some tests.
  
  This PR builds on top of #45 so wait for it to be merged before reviewing.