### PR TITLE
Fix CHANGELOG in readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,8 +7,7 @@ build:
   jobs:
     post_checkout:
       # Create temp dir for git-lfs
-      - export GIT_LFS_DIR=/tmp/git-lfs
-      - echo ${GIT_LFS_DIR}
+      - export GIT_LFS_DIR="/tmp/git-lfs" && echo git_lfs_dir=$GIT_LFS_DIR
       - mkdir -p $GIT_LFS_DIR
 
       # Download and uncompress the binary

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
     post_checkout:
       # Create temp dir for git-lfs
       - export GIT_LFS_DIR=/tmp/git-lfs
-      - echo $GIT_LFS_DIR
+      - echo ${GIT_LFS_DIR}
       - mkdir -p $GIT_LFS_DIR
 
       # Download and uncompress the binary

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,7 @@ build:
     post_checkout:
       # Create temp dir for git-lfs
       - export GIT_LFS_DIR=/tmp/git-lfs
+      - echo $GIT_LFS_DIR
       - mkdir -p $GIT_LFS_DIR
 
       # Download and uncompress the binary

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,20 +6,23 @@ build:
     python: "mambaforge-4.10"
   jobs:
     post_checkout:
+      # Create temp dir for git-lfs
+      - export GIT_LFS_DIR=/tmp/git-lfs
+      - mkdir -p $GIT_LFS_DIR
+
       # Download and uncompress the binary
       # https://git-lfs.github.com/
-      - wget https://github.com/git-lfs/git-lfs/releases/download/v3.1.4/git-lfs-linux-amd64-v3.1.4.tar.gz
-      - tar xvfz git-lfs-linux-amd64-v3.1.4.tar.gz
-      # Modify LFS config paths to point where git-lfs binary was downloaded
-      - git config filter.lfs.process "`pwd`/git-lfs filter-process"
-      - git config filter.lfs.smudge  "`pwd`/git-lfs smudge -- %f"
-      - git config filter.lfs.clean "`pwd`/git-lfs clean -- %f"
-      # Make LFS available in current repository
-      - ./git-lfs install
-      # Download content from remote
-      - ./git-lfs fetch
-      # Make local files to have the real content on them
-      - ./git-lfs checkout
+      - wget -qO- https://github.com/git-lfs/git-lfs/releases/download/v3.1.4/git-lfs-linux-amd64-v3.1.4.tar.gz | tar xz -C $GIT_LFS_DIR
+
+      # Set custom git-lfs binary
+      - git config filter.lfs.process "$GIT_LFS_DIR/git-lfs filter-process"
+      - git config filter.lfs.smudge  "$GIT_LFS_DIR/git-lfs smudge -- %f"
+      - git config filter.lfs.clean "$GIT_LFS_DIR/git-lfs clean -- %f"
+
+      # Use it to fetch large files
+      - $GIT_LFS_DIR/git-lfs install
+      - $GIT_LFS_DIR/git-lfs fetch
+      - $GIT_LFS_DIR/git-lfs checkout
 mkdocs:
   configuration: mkdocs.yaml
   fail_on_warning: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,22 +7,21 @@ build:
   jobs:
     post_checkout:
       # Create temp dir for git-lfs
-      - export GIT_LFS_DIR="/tmp/git-lfs" && echo git_lfs_dir=$GIT_LFS_DIR
-      - mkdir -p $GIT_LFS_DIR
+      - mkdir -p /tmp/git-lfs
 
       # Download and uncompress the binary
       # https://git-lfs.github.com/
-      - wget -qO- https://github.com/git-lfs/git-lfs/releases/download/v3.1.4/git-lfs-linux-amd64-v3.1.4.tar.gz | tar xz -C $GIT_LFS_DIR
+      - wget -qO- https://github.com/git-lfs/git-lfs/releases/download/v3.1.4/git-lfs-linux-amd64-v3.1.4.tar.gz | tar xz -C /tmp/git-lfs
 
       # Set custom git-lfs binary
-      - git config filter.lfs.process "$GIT_LFS_DIR/git-lfs filter-process"
-      - git config filter.lfs.smudge  "$GIT_LFS_DIR/git-lfs smudge -- %f"
-      - git config filter.lfs.clean "$GIT_LFS_DIR/git-lfs clean -- %f"
+      - git config filter.lfs.process "/tmp/git-lfs/git-lfs filter-process"
+      - git config filter.lfs.smudge  "/tmp/git-lfs/git-lfs smudge -- %f"
+      - git config filter.lfs.clean "/tmp/git-lfs/git-lfs clean -- %f"
 
       # Use it to fetch large files
-      - $GIT_LFS_DIR/git-lfs install
-      - $GIT_LFS_DIR/git-lfs fetch
-      - $GIT_LFS_DIR/git-lfs checkout
+      - /tmp/git-lfs/git-lfs install
+      - /tmp/git-lfs/git-lfs fetch
+      - /tmp/git-lfs/git-lfs checkout
 mkdocs:
   configuration: mkdocs.yaml
   fail_on_warning: true


### PR DESCRIPTION
`mkdocs` was actually picking up the CHANGELOG.md from the cloning of `git-lfs`. We need to clone it elsewhere so that it doesn't contaminate `docs/changelog.md`