### PR TITLE
Specify tile range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Each release can have sections: "Added", "Changed", "Deprecated", "Removed", "Fi
 
 ### Added
 
+- Option to download only a range of tiles (e.g. only the first half) [a225ad3](https://github.com/gbelouze/geefetch/commit/a225ad37f7b7bd00aea80c6f3adc097dfb7843d3)
 - Generic `resample_reproject_clip` method to ensure that operations done in correct order (according to GEE docs) [c4c37626](https://github.com/gbelouze/geefetch/commit/c4c3762623901dd1fa4f32fe3e5d99e4b2dc4b98)
 - Choose to apply refined lee filter to PALSAR-2 images [ac50c1e3](https://github.com/gbelouze/geefetch/commit/ac50c1e324a4f30d423895d87d963f365b4ad093)
 - Allow choice of resampling method for downloaded images [7c3da39f](https://github.com/gbelouze/geefetch/commit/7c3da39f5504baa2535bc8936dab33f767ade193)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Each release can have sections: "Added", "Changed", "Deprecated", "Removed", "Fi
 
 ### Added
 
-- Option to download only a range of tiles (e.g. only the first half) [a225ad3](https://github.com/gbelouze/geefetch/commit/a225ad37f7b7bd00aea80c6f3adc097dfb7843d3)
+- Option to download only a range of tiles (e.g. only the first half) in order to support manual parallelization [a225ad3](https://github.com/gbelouze/geefetch/commit/a225ad37f7b7bd00aea80c6f3adc097dfb7843d3)
 - Generic `resample_reproject_clip` method to ensure that operations done in correct order (according to GEE docs) [c4c37626](https://github.com/gbelouze/geefetch/commit/c4c3762623901dd1fa4f32fe3e5d99e4b2dc4b98)
 - Choose to apply refined lee filter to PALSAR-2 images [ac50c1e3](https://github.com/gbelouze/geefetch/commit/ac50c1e324a4f30d423895d87d963f365b4ad093)
 - Allow choice of resampling method for downloaded images [7c3da39f](https://github.com/gbelouze/geefetch/commit/7c3da39f5504baa2535bc8936dab33f767ade193)
@@ -27,7 +27,6 @@ Each release can have sections: "Added", "Changed", "Deprecated", "Removed", "Fi
 
 ### Added
 
-- Option to download a range of tiles in order to support manual parallelization [f2169ce](https://github.com/gbelouze/geefetch/commit/f2169cebac559dd5bd0c7ef883b485f465f38ab1)
 - Option to download satellites from unsupported ImageCollection, with minimal processing [d61bca3](https://github.com/gbelouze/geefetch/commit/d61bca35122914923166551433dd9bb960b0e8cf)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Each release can have sections: "Added", "Changed", "Deprecated", "Removed", "Fi
 
 ### Added
 
+- Option to download a range of tiles in order to support manual parallelization [f2169ce](https://github.com/gbelouze/geefetch/commit/f2169cebac559dd5bd0c7ef883b485f465f38ab1)
 - Option to download satellites from unsupported ImageCollection, with minimal processing [d61bca3](https://github.com/gbelouze/geefetch/commit/d61bca35122914923166551433dd9bb960b0e8cf)
 
 ### Changed

--- a/src/geefetch/cli/download_implementation.py
+++ b/src/geefetch/cli/download_implementation.py
@@ -58,13 +58,14 @@ def save_config(
     config: Any,
     dir: Path,
 ) -> None:
-    """When `geefetch` is called with a specified configuration file,
-    save it to the tracker root."""
+    """When `geefetch` is called with a specified configuration file, save it to the tracker root"""
     if not dir.exists():
         dir.mkdir()
-    suffix = f"_tiles_{config.tile_range[0]}" if config.tile_range is not None else ""
-    config_path = Path(dir / f"config{suffix}.yaml")
+    config_path = Path(dir / "config.yaml")
     config = OmegaConf.to_container(omegaconf.DictConfig(config))
+
+    del config["tile_range"]
+    del config["gee"]["ee_project_id"]
     config["geefetch_version"] = geefetch.__version__
     config_yaml = OmegaConf.to_yaml(config)
     if config_path.exists():

--- a/src/geefetch/cli/download_implementation.py
+++ b/src/geefetch/cli/download_implementation.py
@@ -151,7 +151,7 @@ def download_s1(config_path: Path) -> None:
     if config.s1.selected_bands is None:
         config.s1.selected_bands = satellites.S1().default_selected_bands
     suffix = f"_tiles_{config.s1.tile_range[0]}" if config.s1.tile_range is not None else ""
-    save_config(config.gedi, config.data_dir / "s1", suffix=suffix)
+    save_config(config.s1, config.data_dir / "s1", suffix=suffix)
 
     data_dir = Path(config.data_dir)
     auth(config.s1.gee.ee_project_id)

--- a/src/geefetch/cli/download_implementation.py
+++ b/src/geefetch/cli/download_implementation.py
@@ -54,11 +54,15 @@ def load_country_filter_polygon(country: Any) -> shapely.Polygon | shapely.Multi
     return shapely.ops.unary_union(polygons)
 
 
-def save_config(config: Any, dir: Path, suffix: str = "") -> None:
+def save_config(
+    config: Any,
+    dir: Path,
+) -> None:
     """When `geefetch` is called with a specified configuration file,
     save it to the tracker root."""
     if not dir.exists():
         dir.mkdir()
+    suffix = f"_tiles_{config.tile_range[0]}" if config.tile_range is not None else ""
     config_path = Path(dir / f"config{suffix}.yaml")
     config = OmegaConf.to_container(omegaconf.DictConfig(config))
     config["geefetch_version"] = geefetch.__version__
@@ -90,8 +94,7 @@ def download_gedi(config_path: Path, vector: bool) -> None:
         if config.gedi.selected_bands is None:
             config.gedi.selected_bands = satellites.GEDIvector().default_selected_bands
 
-        suffix = f"_tiles_{config.gedi.tile_range[0]}" if config.gedi.tile_range is not None else ""
-        save_config(config.gedi, config.data_dir / "gedi_vector", suffix=suffix)
+        save_config(config.gedi, config.data_dir / "gedi_vector")
         data.get.download_gedi_vector(
             data_dir,
             bounds,
@@ -137,6 +140,7 @@ def download_gedi(config_path: Path, vector: bool) -> None:
                 if config.gedi.aoi.country is None
                 else load_country_filter_polygon(config.gedi.aoi.country)
             ),
+            tile_range=config.gedi.tile_range,
         )
 
 
@@ -150,8 +154,7 @@ def download_s1(config_path: Path) -> None:
         )
     if config.s1.selected_bands is None:
         config.s1.selected_bands = satellites.S1().default_selected_bands
-    suffix = f"_tiles_{config.s1.tile_range[0]}" if config.s1.tile_range is not None else ""
-    save_config(config.s1, config.data_dir / "s1", suffix=suffix)
+    save_config(config.s1, config.data_dir / "s1")
 
     data_dir = Path(config.data_dir)
     auth(config.s1.gee.ee_project_id)
@@ -220,6 +223,7 @@ def download_s2(config_path: Path) -> None:
         ),
         cloudless_portion=config.s2.cloudless_portion,
         cloud_prb_thresh=config.s2.cloud_prb_threshold,
+        tile_range=config.s2.tile_range,
     )
 
 
@@ -261,6 +265,7 @@ def download_dynworld(config_path: Path) -> None:
             if config.dynworld.aoi.country is None
             else load_country_filter_polygon(config.dynworld.aoi.country)
         ),
+        tile_range=config.dynworld.tile_range,
     )
 
 
@@ -302,6 +307,7 @@ def download_landsat8(config_path: Path) -> None:
             if config.landsat8.aoi.country is None
             else load_country_filter_polygon(config.landsat8.aoi.country)
         ),
+        tile_range=config.landsat8.tile_range,
     )
 
 
@@ -342,6 +348,7 @@ def download_palsar2(config_path: Path) -> None:
             else load_country_filter_polygon(config.palsar2.aoi.country)
         ),
         orbit=config.palsar2.orbit,
+        tile_range=config.palsar2.tile_range,
     )
 
 
@@ -383,6 +390,7 @@ def download_nasadem(config_path: Path) -> None:
             if config.nasadem.aoi.country is None
             else load_country_filter_polygon(config.nasadem.aoi.country)
         ),
+        tile_range=config.nasadem.tile_range,
     )
 
 
@@ -430,6 +438,7 @@ def download_custom(config_path: Path, custom_name: str) -> None:
             if custom_config.aoi.country is None
             else load_country_filter_polygon(custom_config.aoi.country)
         ),
+        tile_range=custom_config.tile_range,
     )
 
 

--- a/src/geefetch/cli/omegaconfig.py
+++ b/src/geefetch/cli/omegaconfig.py
@@ -143,6 +143,9 @@ class SatelliteDefaultConfig:
     selected_bands : list[str] | None
         The bands to download. If None, will use the satellite
         default bands. Defaults to None.
+    tile_range : tuple[int, int] | None
+        Start and end tile indices to download, e.g., (5, 10) to download tiles 5 to 10.
+        If None, all tiles are downloaded. Defaults to None.
     """
 
     aoi: AOIConfig
@@ -152,6 +155,7 @@ class SatelliteDefaultConfig:
     dtype: DType = DType.Float32
     composite_method: CompositeMethod = CompositeMethod.MEDIAN
     selected_bands: list[str] | None = None
+    tile_range: tuple[int, int] | None = None
 
 
 @dataclass

--- a/src/geefetch/cli/omegaconfig.py
+++ b/src/geefetch/cli/omegaconfig.py
@@ -143,9 +143,9 @@ class SatelliteDefaultConfig:
     selected_bands : list[str] | None
         The bands to download. If None, will use the satellite
         default bands. Defaults to None.
-    tile_range : tuple[int, int] | None
-        Start and end tile indices to download, e.g., (5, 10) to download tiles 5 to 10.
-        If None, all tiles are downloaded. Defaults to None.
+    tile_range : tuple[float, float] | None
+        Start and end tile percentage to download, e.g., (0.66, 1.) to download the last
+        third of all tiles. If None, all tiles are downloaded. Defaults to None.
     """
 
     aoi: AOIConfig
@@ -155,7 +155,7 @@ class SatelliteDefaultConfig:
     dtype: DType = DType.Float32
     composite_method: CompositeMethod = CompositeMethod.MEDIAN
     selected_bands: list[str] | None = None
-    tile_range: tuple[int, int] | None = None
+    tile_range: tuple[float, float] | None = None
 
 
 @dataclass

--- a/src/geefetch/data/downloadables/geedim.py
+++ b/src/geefetch/data/downloadables/geedim.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import re
 import threading
 import traceback
@@ -60,7 +59,7 @@ class PatchedBaseImage(BaseImage):  # type: ignore[misc]
         progress: Progress | None = None,
         **kwargs: Any,
     ) -> None:
-        max_threads = num_threads or min(10, (os.cpu_count() or 1) + 4)
+        max_threads = 39
         geedim_log.debug(f"Using {max_threads} threads for download.")
         out_lock = threading.Lock()
         filename = Path(filename)

--- a/src/geefetch/data/get.py
+++ b/src/geefetch/data/get.py
@@ -461,6 +461,7 @@ def download_gedi(
     composite_method: CompositeMethod = CompositeMethod.MEDIAN,
     dtype: DType = DType.Float32,
     filter_polygon: shapely.Geometry | None = None,
+    tile_range: tuple[int, int] | None = None,
 ) -> None:
     """Download GEDI images fused as rasters. Images are written in several .tif chips
     to `data_dir`. Additionally, a file `gedi.vrt` is written to combine all the chips.
@@ -495,6 +496,9 @@ def download_gedi(
         The data type of the downloaded images. Defaults to DType.Float32.
     filter_polygon : shapely.Geometry | None
         More fine-grained AOI than `bbox`. Defaults to None.
+    tile_range: tuple[int, int] | None
+        Start and end tile indices to download, e.g., (5, 10) to download tiles 5 to 10.
+        If None, all tiles are downloaded. Defaults to None.
     """
     download_func = (
         download_time_series if composite_method == CompositeMethod.TIMESERIES else download
@@ -519,6 +523,7 @@ def download_gedi(
             "dtype": dtype,
         },
         satellite_download_kwargs={"dtype": dtype.to_str()},
+        tile_range=tile_range,
     )
 
 
@@ -693,6 +698,7 @@ def download_s2(
     filter_polygon: shapely.Geometry | None = None,
     cloudless_portion: int = 60,
     cloud_prb_thresh: int = 40,
+    tile_range: tuple[int, int] | None = None,
 ) -> None:
     """Download Sentinel-2 images. Images are written in several .tif chips
     to `data_dir`. Additionally, a file `s2.vrt` is written to combine all the chips.
@@ -732,6 +738,9 @@ def download_s2(
         See :meth:`geefetch.data.s2.get`. Defaults to 60.
     cloud_prb_thresh : int
         Cloud probability threshold. See :meth:`geefetch.data.s2.get`. Defaults to 40.
+    tile_range: tuple[int, int] | None
+        Start and end tile indices to download, e.g., (5, 10) to download tiles 5 to 10.
+        If None, all tiles are downloaded. Defaults to None.
     """
     download_func = (
         download_time_series if composite_method == CompositeMethod.TIMESERIES else download
@@ -757,6 +766,7 @@ def download_s2(
             "dtype": dtype,
         },
         satellite_download_kwargs={"dtype": dtype.to_str()},
+        tile_range=tile_range,
     )
 
 
@@ -773,6 +783,7 @@ def download_dynworld(
     composite_method: CompositeMethod = CompositeMethod.MEDIAN,
     dtype: DType = DType.Float32,
     filter_polygon: shapely.Geometry | None = None,
+    tile_range: tuple[int, int] | None = None,
 ) -> None:
     """Download Dynamic World images. Images are written in several .tif chips
     to `data_dir`. Additionnally a file `dynworld.vrt` is written to combine all the chips.
@@ -807,6 +818,9 @@ def download_dynworld(
         The data type of the downloaded images. Defaults to DType.Float32.
     filter_polygon : shapely.Geometry | None
         More fine-grained AOI than `bbox`. Defaults to None.
+    tile_range: tuple[int, int] | None
+        Start and end tile indices to download, e.g., (5, 10) to download tiles 5 to 10.
+        If None, all tiles are downloaded. Defaults to None.
     """
     download_func = (
         download_time_series if composite_method == CompositeMethod.TIMESERIES else download
@@ -830,6 +844,7 @@ def download_dynworld(
             "dtype": dtype,
         },
         satellite_download_kwargs={"dtype": dtype.to_str()},
+        tile_range=tile_range,
     )
 
 
@@ -846,6 +861,7 @@ def download_landsat8(
     composite_method: CompositeMethod = CompositeMethod.MEDIAN,
     dtype: DType = DType.Float32,
     filter_polygon: shapely.Geometry | None = None,
+    tile_range: tuple[int, int] | None = None,
 ) -> None:
     """Download Landsat 8 images. Images are written in several .tif chips
     to `data_dir`. Additionally, a file `landsat8.vrt` is written to combine all the chips.
@@ -880,6 +896,9 @@ def download_landsat8(
         The data type of the downloaded images. Defaults to DType.Float32.
     filter_polygon : shapely.Geometry | None
         More fine-grained AOI than `bbox`. Defaults to None.
+    tile_range: tuple[int, int] | None
+        Start and end tile indices to download, e.g., (5, 10) to download tiles 5 to 10.
+        If None, all tiles are downloaded. Defaults to None.
     """
     download_func = (
         download_time_series if composite_method == CompositeMethod.TIMESERIES else download
@@ -901,6 +920,7 @@ def download_landsat8(
             "dtype": dtype,
         },
         satellite_download_kwargs={"dtype": dtype.to_str()},
+        tile_range=tile_range,
     )
 
 
@@ -918,6 +938,7 @@ def download_palsar2(
     dtype: DType = DType.Float32,
     filter_polygon: shapely.Geometry | None = None,
     orbit: P2Orbit = P2Orbit.DESCENDING,
+    tile_range: tuple[int, int] | None = None,
 ) -> None:
     """Download Palsar 2 images. Images are written in several .tif chips
     to `data_dir`. Additionally, a file `palsar2.vrt` is written to combine all the chips.
@@ -954,7 +975,9 @@ def download_palsar2(
         More fine-grained AOI than `bbox`. Defaults to None.
     orbit : P2Orbit
         The orbit used to filter Palsar-2 images. Defaults to P2Orbit.ASCENDING.
-
+    tile_range: tuple[int, int] | None
+        Start and end tile indices to download, e.g., (5, 10) to download tiles 5 to 10.
+        If None, all tiles are downloaded. Defaults to None.
     """
     download_func = (
         download_time_series if composite_method == CompositeMethod.TIMESERIES else download
@@ -977,6 +1000,7 @@ def download_palsar2(
             "orbit": orbit,
         },
         satellite_download_kwargs={"dtype": dtype.to_str()},
+        tile_range=tile_range,
     )
 
 
@@ -991,6 +1015,7 @@ def download_nasadem(
     composite_method: CompositeMethod = CompositeMethod.MEDIAN,
     dtype: DType = DType.Float32,
     filter_polygon: shapely.Polygon | None = None,
+    tile_range: tuple[int, int] | None = None,
 ) -> None:
     """Download NASADEM images. Images are written in several .tif chips
     to `data_dir`. Additionally, a file `nasadem.vrt` is written to combine all the chips.
@@ -1021,6 +1046,9 @@ def download_nasadem(
         The data type of the downloaded images. Defaults to DType.Float32.
     filter_polygon : shapely.Polygon | None
         More fine-grained AOI than `bbox`. Defaults to None.
+    tile_range: tuple[int, int] | None
+        Start and end tile indices to download, e.g., (5, 10) to download tiles 5 to 10.
+        If None, all tiles are downloaded. Defaults to None.
     """
     if composite_method == CompositeMethod.TIMESERIES:
         raise ValueError("Time series is not relevant for DEM.")
@@ -1043,6 +1071,7 @@ def download_nasadem(
             "dtype": dtype,
         },
         satellite_download_kwargs={"dtype": dtype.to_str()},
+        tile_range=tile_range,
     )
 
 
@@ -1060,6 +1089,7 @@ def download_custom(
     composite_method: CompositeMethod = CompositeMethod.MEDIAN,
     dtype: DType = DType.Float32,
     filter_polygon: shapely.Polygon | None = None,
+    tile_range: tuple[int, int] | None = None,
 ) -> None:
     """Download images from a custom data source. Images are written in several .tif chips
     to `data_dir`. Additionally, a file `nasadem.vrt` is written to combine all the chips.
@@ -1095,6 +1125,9 @@ def download_custom(
         The data type of the downloaded images. Defaults to DType.Float32.
     filter_polygon : shapely.Polygon | None
         More fine-grained AOI than `bbox`. Defaults to None.
+    tile_range: tuple[int, int] | None
+        Start and end tile indices to download, e.g., (5, 10) to download tiles 5 to 10.
+        If None, all tiles are downloaded. Defaults to None.
     """
     if composite_method == CompositeMethod.TIMESERIES:
         raise ValueError("Time series is not relevant for Custom Satellites.")
@@ -1117,4 +1150,5 @@ def download_custom(
             "dtype": dtype,
         },
         satellite_download_kwargs={"dtype": dtype.to_str()},
+        tile_range=tile_range,
     )

--- a/src/geefetch/data/get.py
+++ b/src/geefetch/data/get.py
@@ -1064,7 +1064,7 @@ def download_nasadem(
         tile_shape=tile_shape,
         max_tile_size=max_tile_size,
         in_parallel=True,
-        max_workers=3,
+        max_workers=1,
         filter_polygon=filter_polygon,
         satellite_get_kwargs={
             "composite_method": composite_method,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -66,14 +66,27 @@ def paris_config_selected_bands_path(
 
 
 @pytest.fixture
-def paris_config_tile_range_path(
+def paris_config_tile_range_path_first_half(
     raw_paris_config: DictConfig, tmp_path: Path, gee_project_id: str
 ) -> Path:
     raw_paris_config.data_dir = str(tmp_path)
     raw_paris_config.satellite_default.gee.ee_project_id = gee_project_id
     raw_paris_config.satellite_default.aoi.spatial.right = 660001
-    raw_paris_config["s1"] = {"tile_range": (0.5, 1.)} | dict(raw_paris_config.get("s1", {}))
-    conf_path = tmp_path / "config.yaml"
+    raw_paris_config["s1"] = {"tile_range": (0.0, 0.5)} | dict(raw_paris_config.get("s1", {}))
+    conf_path = tmp_path / "config_first_half.yaml"
+    conf_path.write_text(OmegaConf.to_yaml(raw_paris_config))
+    return conf_path
+
+
+@pytest.fixture
+def paris_config_tile_range_path_second_half(
+    raw_paris_config: DictConfig, tmp_path: Path, gee_project_id: str
+) -> Path:
+    raw_paris_config.data_dir = str(tmp_path)
+    raw_paris_config.satellite_default.gee.ee_project_id = gee_project_id
+    raw_paris_config.satellite_default.aoi.spatial.right = 660001
+    raw_paris_config["s1"] = {"tile_range": (0.5, 1.0)} | dict(raw_paris_config.get("s1", {}))
+    conf_path = tmp_path / "config_second_half.yaml"
     conf_path.write_text(OmegaConf.to_yaml(raw_paris_config))
     return conf_path
 
@@ -152,12 +165,24 @@ class TestDownloadSentinel1:
             assert len(downloaded_files) == 1
             assert downloaded_files[0].parts[-2:] == ("s1", "s1_EPSG2154_650000_6860000.tif")
 
-    def test_download_s1_tile_range(self, paris_config_tile_range_path: Path):
-        download_s1(paris_config_tile_range_path)
-        conf = load(paris_config_tile_range_path)
+    def test_download_s1_tile_range_last_half(self, paris_config_tile_range_path_second_half: Path):
+        download_s1(paris_config_tile_range_path_second_half)
+        conf = load(paris_config_tile_range_path_second_half)
         downloaded_files = list(Path(conf.data_dir).rglob("*.tif"))
         assert len(downloaded_files) == 1
         assert downloaded_files[0].parts[-2:] == ("s1", "s1_EPSG2154_660000_6860000.tif")
+
+    def test_download_s1_tile_range_first_half_then_last_half(
+        self,
+        paris_config_tile_range_path_first_half: Path,
+        paris_config_tile_range_path_second_half: Path,
+    ):
+        download_s1(paris_config_tile_range_path_first_half)
+        download_s1(paris_config_tile_range_path_second_half)
+        conf = load(paris_config_tile_range_path_first_half)
+        downloaded_files = sorted(list(Path(conf.data_dir).rglob("*.tif")))
+        assert len(downloaded_files) == 2
+        assert downloaded_files[0].parts[-2:] == ("s1", "s1_EPSG2154_650000_6860000.tif")
 
 
 class TestDownloadGedi:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -72,7 +72,7 @@ def paris_config_tile_range_path(
     raw_paris_config.data_dir = str(tmp_path)
     raw_paris_config.satellite_default.gee.ee_project_id = gee_project_id
     raw_paris_config.satellite_default.aoi.spatial.right = 660001
-    raw_paris_config["s1"] = {"tile_range": [1, 2]} | dict(raw_paris_config.get("s1", {}))
+    raw_paris_config["s1"] = {"tile_range": (0.5, 1.)} | dict(raw_paris_config.get("s1", {}))
     conf_path = tmp_path / "config.yaml"
     conf_path.write_text(OmegaConf.to_yaml(raw_paris_config))
     return conf_path

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,6 +25,7 @@ from geefetch.utils.enums import CompositeMethod, P2Orbit, S1Orbit
 def paris_config_path(
     raw_paris_config: DictConfig, tmp_path: Path, gee_project_id: str
 ) -> Generator[Path]:
+    raw_paris_config = raw_paris_config.copy()
     raw_paris_config.data_dir = str(tmp_path)
     raw_paris_config.satellite_default.gee.ee_project_id = gee_project_id
 
@@ -38,6 +39,7 @@ def paris_config_path(
 def paris_timeseriesconfig_path(
     raw_paris_config: DictConfig, tmp_path: Path, gee_project_id: str
 ) -> Path:
+    raw_paris_config = raw_paris_config.copy()
     raw_paris_config.data_dir = str(tmp_path)
     raw_paris_config.satellite_default.gee.ee_project_id = gee_project_id
     raw_paris_config.satellite_default.composite_method = CompositeMethod.TIMESERIES
@@ -51,6 +53,7 @@ def paris_timeseriesconfig_path(
 def paris_config_selected_bands_path(
     raw_paris_config: DictConfig, tmp_path: Path, gee_project_id: str
 ) -> Path:
+    raw_paris_config = raw_paris_config.copy()
     raw_paris_config.data_dir = str(tmp_path)
     raw_paris_config.satellite_default.gee.ee_project_id = gee_project_id
     raw_paris_config["s1"] = {"selected_bands": ["VV", "VH", "angle"]} | dict(
@@ -69,6 +72,7 @@ def paris_config_selected_bands_path(
 def paris_config_tile_range_path_first_half(
     raw_paris_config: DictConfig, tmp_path: Path, gee_project_id: str
 ) -> Path:
+    raw_paris_config = raw_paris_config.copy()
     raw_paris_config.data_dir = str(tmp_path)
     raw_paris_config.satellite_default.gee.ee_project_id = gee_project_id
     raw_paris_config.satellite_default.aoi.spatial.right = 660001
@@ -82,6 +86,7 @@ def paris_config_tile_range_path_first_half(
 def paris_config_tile_range_path_second_half(
     raw_paris_config: DictConfig, tmp_path: Path, gee_project_id: str
 ) -> Path:
+    raw_paris_config = raw_paris_config.copy()
     raw_paris_config.data_dir = str(tmp_path)
     raw_paris_config.satellite_default.gee.ee_project_id = gee_project_id
     raw_paris_config.satellite_default.aoi.spatial.right = 660001


### PR DESCRIPTION
- Option to specify a range of tiles to download instead of entire AOI (this is useful for manual parallelisation)
- Optimised use of threads and workers. Max threads = 39 to avoid download errors and max_workers always 1 for simplicity