### PR TITLE
fix(Dependencies): Changed the geedim dependency to be < 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = ["version"]
 dependencies = [
     "click>=8.2.0",
     "earthengine-api",
-    "geedim",
+    "geedim<2.0.0",
     "geobbox>=0.1.0",
     "geopandas>=1.0.1",
     "jsons",


### PR DESCRIPTION
Following the issue I raised, this pr simply adds the `geedim<2.0.0` condition to the pyproject.toml.