### PR TITLE
S1 GEE Preprocessing based on Adugna Mullissa's gee_s1_ard repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+*.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Each release can have sections: "Added", "Changed", "Deprecated", "Removed", "Fi
 - Generic `resample_reproject_clip` method to ensure that operations done in correct order (according to GEE docs) [c4c37626](https://github.com/gbelouze/geefetch/commit/c4c3762623901dd1fa4f32fe3e5d99e4b2dc4b98)
 - Choose to apply refined lee filter to PALSAR-2 images [ac50c1e3](https://github.com/gbelouze/geefetch/commit/ac50c1e324a4f30d423895d87d963f365b4ad093)
 - Allow choice of resampling method for downloaded images [7c3da39f](https://github.com/gbelouze/geefetch/commit/7c3da39f5504baa2535bc8936dab33f767ade193)
+- 2 New data classes to configure speckle filtering and terrain flattening for s1 images [9a2cc37](https://github.com/gbelouze/geefetch/commit/9a2cc3782e4016c6e609ec68b17a1ad986d3db5b). This was done via the added dependency to [gee_s1_processing](https://github.com/LSCE-forest/gee_s1_processing) which is a fork of [gee_s1_ard](https://github.com/adugnag/gee_s1_ard)
 
 ### Changed
 

--- a/docs/satellites/sentinel1.md
+++ b/docs/satellites/sentinel1.md
@@ -39,23 +39,6 @@ See [common configuration options](../api/cli/configuration.md#geefetch.cli.omeg
       show_bases: false
       show_root_toc_entry: false
 
-### gee_s1_ard filter parameters
-
-The gee_s1_ard filters are taken from this [gee_s1_ard fork](https://github.com/LSCE-forest/gee_s1_processing/) repository. See related paper [here](https://www.mdpi.com/2072-4292/13/10/1954).
-
-| Parameter                                         | Type  | Description |
-|---------------------------------------------------|-------|-------------|
-|apply_border_noise_correction                      |boolean| Apply border noise correction if True
-|apply_terrain_flattening                           |boolean| Apply terrain flattening if True
-|apply_speckle_filtering                            |boolean| Apply speckel filtering if True
-|dem                                                |string | Digital elevation Model used for terrain corrections. See
-|speckle_filter_framework                           |string | 
-|speckle_filter                                     |string |
-|speckle_filter_kernel_size                         |integer|
-|speckle_filter_nr_of_images                        |integer|
-|terrain_flattening_model                           |string |
-|terrain_flattening_additional_layover_shadow_buffer|integer|
-
 ## Example Usage
 
 ### Command Line
@@ -81,16 +64,14 @@ satellite_default:
   resolution: 10
 s1:
   orbit: ASCENDING
-  filter_params:
-        apply_border_noise_correction: false
-        apply_terrain_flattening: false
-        apply_speckle_filtering: false
-        dem: 'USGS/SRTMGL1_003'
+  speckle_filter_config:
         speckle_filter_framework: 'MONO'
         speckle_filter: 'BOXCAR'
         speckle_filter_kernel_size: 3
         speckle_filter_nr_of_images: 10
+  terrain_normalization_config:
         terrain_flattening_model: 'DIRECT'
+        dem: 'USGS/SRTMGL1_003'
         terrain_flattening_additional_layover_shadow_buffer: 0
 ```
 
@@ -99,6 +80,8 @@ then download with
 ```bash
 geefetch s1 -c config.yaml
 ```
+
+For more information on the [speckle_filter_config](https://github.com/LSCE-forest/gee_s1_processing/blob/main/doc/Speckle_Filters.md) and [terrain_normalization_config](https://github.com/LSCE-forest/gee_s1_processing/blob/main/doc/Terrain_Normalization.md).
 
 ### Python API
 

--- a/docs/satellites/sentinel1.md
+++ b/docs/satellites/sentinel1.md
@@ -39,6 +39,23 @@ See [common configuration options](../api/cli/configuration.md#geefetch.cli.omeg
       show_bases: false
       show_root_toc_entry: false
 
+### gee_s1_ard filter parameters
+
+The gee_s1_ard filters are taken from this [gee_s1_ard fork](https://github.com/LSCE-forest/gee_s1_processing/) repository. See related paper [here](https://www.mdpi.com/2072-4292/13/10/1954).
+
+| Parameter                                         | Type  | Description |
+|---------------------------------------------------|-------|-------------|
+|apply_border_noise_correction                      |boolean| Apply border noise correction if True
+|apply_terrain_flattening                           |boolean| Apply terrain flattening if True
+|apply_speckle_filtering                            |boolean| Apply speckel filtering if True
+|dem                                                |string | Digital elevation Model used for terrain corrections. See
+|speckle_filter_framework                           |string | 
+|speckle_filter                                     |string |
+|speckle_filter_kernel_size                         |integer|
+|speckle_filter_nr_of_images                        |integer|
+|terrain_flattening_model                           |string |
+|terrain_flattening_additional_layover_shadow_buffer|integer|
+
 ## Example Usage
 
 ### Command Line

--- a/docs/satellites/sentinel1.md
+++ b/docs/satellites/sentinel1.md
@@ -39,23 +39,6 @@ See [common configuration options](../api/cli/configuration.md#geefetch.cli.omeg
       show_bases: false
       show_root_toc_entry: false
 
-### gee_s1_ard filter parameters
-
-The gee_s1_ard filters are taken from this [gee_s1_ard fork](https://github.com/LSCE-forest/gee_s1_processing/) repository. See related paper [here](https://www.mdpi.com/2072-4292/13/10/1954).
-
-| Parameter                                         | Type  | Description |
-|---------------------------------------------------|-------|-------------|
-|apply_border_noise_correction                      |boolean| Apply border noise correction if True
-|apply_terrain_flattening                           |boolean| Apply terrain flattening if True
-|apply_speckle_filtering                            |boolean| Apply speckel filtering if True
-|dem                                                |string | Digital elevation Model used for terrain corrections. See
-|speckle_filter_framework                           |string | 
-|speckle_filter                                     |string |
-|speckle_filter_kernel_size                         |integer|
-|speckle_filter_nr_of_images                        |integer|
-|terrain_flattening_model                           |string |
-|terrain_flattening_additional_layover_shadow_buffer|integer|
-
 ## Example Usage
 
 ### Command Line

--- a/docs/satellites/sentinel1.md
+++ b/docs/satellites/sentinel1.md
@@ -32,12 +32,29 @@ See [common configuration options](../api/cli/configuration.md#geefetch.cli.omeg
 ::: geefetch.cli.omegaconfig.S1Config
 
     options:
-        show_source: false
-        show_signature: false
-        show_category_heading: false
-        show_docstring_description: false
-        show_bases: false
-        show_root_toc_entry: false
+      show_source: false
+      show_signature: false
+      show_category_heading: false
+      show_docstring_description: false
+      show_bases: false
+      show_root_toc_entry: false
+
+### gee_s1_ard filter parameters
+
+The gee_s1_ard filters are taken from this [gee_s1_ard fork](https://github.com/LSCE-forest/gee_s1_processing/) repository. See related paper [here](https://www.mdpi.com/2072-4292/13/10/1954).
+
+| Parameter                                         | Type  | Description |
+|---------------------------------------------------|-------|-------------|
+|apply_border_noise_correction                      |boolean| Apply border noise correction if True
+|apply_terrain_flattening                           |boolean| Apply terrain flattening if True
+|apply_speckle_filtering                            |boolean| Apply speckel filtering if True
+|dem                                                |string | Digital elevation Model used for terrain corrections. See
+|speckle_filter_framework                           |string | 
+|speckle_filter                                     |string |
+|speckle_filter_kernel_size                         |integer|
+|speckle_filter_nr_of_images                        |integer|
+|terrain_flattening_model                           |string |
+|terrain_flattening_additional_layover_shadow_buffer|integer|
 
 ## Example Usage
 
@@ -64,6 +81,17 @@ satellite_default:
   resolution: 10
 s1:
   orbit: ASCENDING
+  filter_params:
+        apply_border_noise_correction: false
+        apply_terrain_flattening: false
+        apply_speckle_filtering: false
+        dem: 'USGS/SRTMGL1_003'
+        speckle_filter_framework: 'MONO'
+        speckle_filter: 'BOXCAR'
+        speckle_filter_kernel_size: 3
+        speckle_filter_nr_of_images: 10
+        terrain_flattening_model: 'DIRECT'
+        terrain_flattening_additional_layover_shadow_buffer: 0
 ```
 
 then download with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "rich",
     "shapely>=2.0.6",
     "thefuzz",
+    "gee_s1_processing @ git+https://github.com/LSCE-forest/gee_s1_processing.git@main",
 ]
 
 [tool.flit.module]

--- a/src/geefetch/cli/download_implementation.py
+++ b/src/geefetch/cli/download_implementation.py
@@ -180,6 +180,8 @@ def download_s1(config_path: Path) -> None:
             if config.s1.aoi.country is None
             else load_country_filter_polygon(config.s1.aoi.country)
         ),
+        speckle_filter_config=config.s1.speckle_filter_config,
+        terrain_normalization_config=config.s1.terrain_normalization_config,
         filter_params=config.s1.filter_params,
         orbit=config.s1.orbit,
         resampling=config.s1.resampling,

--- a/src/geefetch/cli/download_implementation.py
+++ b/src/geefetch/cli/download_implementation.py
@@ -180,6 +180,7 @@ def download_s1(config_path: Path) -> None:
             if config.s1.aoi.country is None
             else load_country_filter_polygon(config.s1.aoi.country)
         ),
+        filter_params=config.s1.filter_params,
         orbit=config.s1.orbit,
         resampling=config.s1.resampling,
         tile_range=config.s1.tile_range,

--- a/src/geefetch/cli/download_implementation.py
+++ b/src/geefetch/cli/download_implementation.py
@@ -182,7 +182,6 @@ def download_s1(config_path: Path) -> None:
         ),
         speckle_filter_config=config.s1.speckle_filter_config,
         terrain_normalization_config=config.s1.terrain_normalization_config,
-        filter_params=config.s1.filter_params,
         orbit=config.s1.orbit,
         resampling=config.s1.resampling,
         tile_range=config.s1.tile_range,

--- a/src/geefetch/cli/omegaconfig.py
+++ b/src/geefetch/cli/omegaconfig.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from gee_s1_processing.wrapper import S1FilterConfig
+from gee_s1_processing.wrapper import SpeckleFilterConfig, TerrainNormalizationConfig
 from geobbox import GeoBoundingBox
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from rasterio.crs import CRS
@@ -188,12 +188,13 @@ class S1Config(SatelliteDefaultConfig):
         Can be ASCENDING, DESCENDING, BOTH, or AS_BANDS
         to download ascending and descending composites as separate bands.
         Defaults to BOTH.
-    filter_config : S1FilterConfig
+    filter_config : SpeckleFilterConfig
     """
 
     # using enum while https://github.com/omry/omegaconf/issues/422 is open
     orbit: S1Orbit = S1Orbit.BOTH
-    filter_params: S1FilterConfig|None = None
+    speckle_filter_config: SpeckleFilterConfig|None = None
+    terrain_normalization_config: TerrainNormalizationConfig|None = None
 
 @dataclass
 class S2Config(SatelliteDefaultConfig):

--- a/src/geefetch/cli/omegaconfig.py
+++ b/src/geefetch/cli/omegaconfig.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from gee_s1_processing.wrapper import S1Filter
 from geobbox import GeoBoundingBox
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from rasterio.crs import CRS
@@ -187,11 +188,12 @@ class S1Config(SatelliteDefaultConfig):
         Can be ASCENDING, DESCENDING, BOTH, or AS_BANDS
         to download ascending and descending composites as separate bands.
         Defaults to BOTH.
+    filter_config : S1Filter
     """
 
     # using enum while https://github.com/omry/omegaconf/issues/422 is open
     orbit: S1Orbit = S1Orbit.BOTH
-
+    filter_params: S1Filter|None = None
 
 @dataclass
 class S2Config(SatelliteDefaultConfig):

--- a/src/geefetch/cli/omegaconfig.py
+++ b/src/geefetch/cli/omegaconfig.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from gee_s1_processing.wrapper import S1Filter
+from gee_s1_processing.wrapper import S1FilterConfig
 from geobbox import GeoBoundingBox
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from rasterio.crs import CRS
@@ -188,12 +188,12 @@ class S1Config(SatelliteDefaultConfig):
         Can be ASCENDING, DESCENDING, BOTH, or AS_BANDS
         to download ascending and descending composites as separate bands.
         Defaults to BOTH.
-    filter_config : S1Filter
+    filter_config : S1FilterConfig
     """
 
     # using enum while https://github.com/omry/omegaconf/issues/422 is open
     orbit: S1Orbit = S1Orbit.BOTH
-    filter_params: S1Filter|None = None
+    filter_params: S1FilterConfig|None = None
 
 @dataclass
 class S2Config(SatelliteDefaultConfig):

--- a/src/geefetch/cli/omegaconfig.py
+++ b/src/geefetch/cli/omegaconfig.py
@@ -189,6 +189,9 @@ class S1Config(SatelliteDefaultConfig):
         to download ascending and descending composites as separate bands.
         Defaults to BOTH.
     filter_config : SpeckleFilterConfig
+        Configuration dataclass for speckle filtering.
+    terrain_normalization_config : TerrainNormalizationConfig
+        Configuration dataclass for terrain normalization.
     """
 
     # using enum while https://github.com/omry/omegaconf/issues/422 is open

--- a/src/geefetch/data/get.py
+++ b/src/geefetch/data/get.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import shapely
 from geobbox import GeoBoundingBox
-from gee_s1_processing.wrapper import S1Filter
+from gee_s1_processing.wrapper import S1FilterConfig
 from rasterio.crs import CRS
 from retry import retry
 from rich.progress import Progress
@@ -620,7 +620,7 @@ def download_s1(
     composite_method: CompositeMethod = CompositeMethod.MEDIAN,
     dtype: DType = DType.Float32,
     filter_polygon: shapely.Geometry | None = None,
-    filter_params: S1Filter = None,
+    filter_params: S1FilterConfig = None,
     orbit: S1Orbit = S1Orbit.ASCENDING,
     resampling: ResamplingMethod = ResamplingMethod.BILINEAR,
     tile_range: tuple[float, float] | None = None,
@@ -658,7 +658,7 @@ def download_s1(
         The data type of the downloaded images. Defaults to DType.Float32.
     filter_polygon : shapely.Geometry | None
         More fine-grained AOI than `bbox`. Defaults to None.
-    filter_params : S1Filter
+    filter_params : S1FilterConfig
         Filter parameters for the gee_s1_processing function. 
     orbit : S1Orbit
         The orbit used to filter Sentinel-1 images. Defaults to S1Orbit.ASCENDING.

--- a/src/geefetch/data/get.py
+++ b/src/geefetch/data/get.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import shapely
 from geobbox import GeoBoundingBox
+from gee_s1_processing.wrapper import S1Filter
 from rasterio.crs import CRS
 from retry import retry
 from rich.progress import Progress
@@ -619,6 +620,7 @@ def download_s1(
     composite_method: CompositeMethod = CompositeMethod.MEDIAN,
     dtype: DType = DType.Float32,
     filter_polygon: shapely.Geometry | None = None,
+    filter_params: S1Filter = None,
     orbit: S1Orbit = S1Orbit.ASCENDING,
     resampling: ResamplingMethod = ResamplingMethod.BILINEAR,
     tile_range: tuple[float, float] | None = None,
@@ -656,6 +658,8 @@ def download_s1(
         The data type of the downloaded images. Defaults to DType.Float32.
     filter_polygon : shapely.Geometry | None
         More fine-grained AOI than `bbox`. Defaults to None.
+    filter_params : S1Filter
+        Filter parameters for the gee_s1_processing function. 
     orbit : S1Orbit
         The orbit used to filter Sentinel-1 images. Defaults to S1Orbit.ASCENDING.
     resampling : ResamplingMethod
@@ -685,7 +689,7 @@ def download_s1(
     download_func(
         data_dir=data_dir,
         bbox=bbox,
-        satellite=S1(),
+        satellite=S1(filter_params),
         start_date=start_date,
         end_date=end_date,
         selected_bands=download_selected_bands,

--- a/src/geefetch/data/get.py
+++ b/src/geefetch/data/get.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import shapely
 from geobbox import GeoBoundingBox
-from gee_s1_processing.wrapper import S1FilterConfig
+from gee_s1_processing.wrapper import SpeckleFilterConfig, TerrainNormalizationConfig
 from rasterio.crs import CRS
 from retry import retry
 from rich.progress import Progress
@@ -620,7 +620,8 @@ def download_s1(
     composite_method: CompositeMethod = CompositeMethod.MEDIAN,
     dtype: DType = DType.Float32,
     filter_polygon: shapely.Geometry | None = None,
-    filter_params: S1FilterConfig = None,
+    speckle_filter_config: SpeckleFilterConfig = None,
+    terrain_normalization_config: TerrainNormalizationConfig = None,
     orbit: S1Orbit = S1Orbit.ASCENDING,
     resampling: ResamplingMethod = ResamplingMethod.BILINEAR,
     tile_range: tuple[float, float] | None = None,
@@ -658,8 +659,10 @@ def download_s1(
         The data type of the downloaded images. Defaults to DType.Float32.
     filter_polygon : shapely.Geometry | None
         More fine-grained AOI than `bbox`. Defaults to None.
-    filter_params : S1FilterConfig
-        Filter parameters for the gee_s1_processing function. 
+    speckle_filter_config : SpeckleFilterConfig
+        speckle_filtering configurations
+    terrain_normalization_config: TerrainNormalizationConfig = None,
+        terrain_normalization configurations
     orbit : S1Orbit
         The orbit used to filter Sentinel-1 images. Defaults to S1Orbit.ASCENDING.
     resampling : ResamplingMethod
@@ -689,7 +692,7 @@ def download_s1(
     download_func(
         data_dir=data_dir,
         bbox=bbox,
-        satellite=S1(filter_params),
+        satellite=S1(speckle_filter_config, terrain_normalization_config),
         start_date=start_date,
         end_date=end_date,
         selected_bands=download_selected_bands,

--- a/src/geefetch/data/satellites/s1.py
+++ b/src/geefetch/data/satellites/s1.py
@@ -285,8 +285,6 @@ class S1(SatelliteABC):
         aoi: GeoBoundingBox,
         scale: float,
     ) -> Image:
-        # Convert from db to power: 10^(im/10)
-        # im = ee.Image(10).pow(im.divide(10))
         # Apply resampling if specified
         im = self.resample_reproject_clip(im, aoi, resampling, scale)
         return im

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from dotenv import load_dotenv
 from pathlib import Path
 
 import pytest
@@ -7,7 +8,7 @@ from omegaconf import DictConfig, ListConfig, OmegaConf
 
 TESTS_DIR = Path(__file__).parent
 GEE_PROJECT_ID_ENV_NAME = "GEEFETCH_GEE_PROJECT_ID"
-
+load_dotenv()
 
 @pytest.fixture
 def raw_paris_config() -> DictConfig | ListConfig:

--- a/tests/data/paris_config.yaml
+++ b/tests/data/paris_config.yaml
@@ -31,6 +31,18 @@ palsar2:
   orbit: DESCENDING
 s1:
   orbit: ASCENDING
+  filter_params:
+      apply_border_noise_correction: true
+      apply_terrain_flattening: true
+      apply_speckle_filtering: true
+      dem: 'USGS/SRTMGL1_003'
+      speckle_filter_framework: 'MONO'
+      speckle_filter: 'BOXCAR'
+      speckle_filter_kernel_size: 3
+      speckle_filter_nr_of_images: 10
+      terrain_flattening_model: 'DIRECT'
+      terrain_flattening_additional_layover_shadow_buffer: 0
+
 customs:
   chm_pauls:
     url: projects/worldwidemap/assets/canopyheight2020


### PR DESCRIPTION
This PR will add the s1 speckle filter and terrain normalization configurations to main.

They add to geefetch a dependency to the fork [gee_s1_processing](https://github.com/LSCE-forest/gee_s1_processing/tree/main/gee_s1_processing) based off of [Adugna Mullissa's](https://github.com/adugnag) branch [gee_s1_ard](https://github.com/adugnag/gee_s1_ard). 

There was a need to revamp his repo into a packaged python module (hence the fork).
The documentation for the configurations was added to my fork to avoid bloating documentation here.

The default configurations set are:
- No speckle filtering
- Terrain Normalization
```yaml
terrain_normalization_config:
    terrain_flattening_model: str = "VOLUME"
    terrain_flattening_additional_layover_shadow_buffer: int = 3
    dem: str = "USGS/SRTMGL1_003"
    angle_band: str = "angle"
```