### PR TITLE
Spawn parallel processes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,3 +158,4 @@ exclude = ['tests/test_download.py', 'tests/conftest.py']
 
 [tool.pyright]
 typeCheckingMode = "off"
+pythonVersion = "3.11"

--- a/src/geefetch/cli/download_implementation.py
+++ b/src/geefetch/cli/download_implementation.py
@@ -14,7 +14,6 @@ import geefetch
 import geefetch.data.satellites as satellites
 from geefetch import data
 from geefetch.utils.config import git_style_diff
-from geefetch.utils.gee import auth
 
 from .omegaconfig import load
 
@@ -64,7 +63,7 @@ def save_config(
     config = OmegaConf.to_container(omegaconf.DictConfig(config))
 
     del config["tile_range"]
-    del config["gee"]["ee_project_id"]
+    del config["gee"]["ee_project_ids"]
     config["geefetch_version"] = geefetch.__version__
     config_yaml = OmegaConf.to_yaml(config)
     if config_path.exists():
@@ -88,7 +87,6 @@ def download_gedi(config_path: Path, vector: bool) -> None:
             "GEDI is not configured. Pass `gedi: {}` in the config file to use `satellite_default`."
         )
     data_dir = Path(config.data_dir)
-    auth(config.gedi.gee.ee_project_id)
     bounds = config.gedi.aoi.spatial.as_bbox()
     if vector:
         if config.gedi.selected_bands is None:
@@ -97,6 +95,7 @@ def download_gedi(config_path: Path, vector: bool) -> None:
         save_config(config.gedi, config.data_dir / "gedi_vector")
         data.get.download_gedi_vector(
             data_dir,
+            config.gedi.gee.ee_project_ids,
             bounds,
             config.gedi.aoi.temporal.start_date if config.gedi.aoi.temporal is not None else None,
             config.gedi.aoi.temporal.end_date if config.gedi.aoi.temporal is not None else None,
@@ -122,6 +121,7 @@ def download_gedi(config_path: Path, vector: bool) -> None:
         save_config(config.gedi, config.data_dir / "gedi_raster")
         data.get.download_gedi(
             data_dir,
+            config.gedi.gee.ee_project_ids,
             bounds,
             config.gedi.aoi.temporal.start_date if config.gedi.aoi.temporal is not None else None,
             config.gedi.aoi.temporal.end_date if config.gedi.aoi.temporal is not None else None,
@@ -157,10 +157,10 @@ def download_s1(config_path: Path) -> None:
     save_config(config.s1, config.data_dir / "s1")
 
     data_dir = Path(config.data_dir)
-    auth(config.s1.gee.ee_project_id)
     bounds = config.s1.aoi.spatial.as_bbox()
     data.get.download_s1(
         data_dir,
+        config.s1.gee.ee_project_ids,
         bounds,
         config.s1.aoi.temporal.start_date if config.s1.aoi.temporal is not None else None,
         config.s1.aoi.temporal.end_date if config.s1.aoi.temporal is not None else None,
@@ -199,10 +199,10 @@ def download_s2(config_path: Path) -> None:
     save_config(config.s2, config.data_dir / "s2")
 
     data_dir = Path(config.data_dir)
-    auth(config.s2.gee.ee_project_id)
     bounds = config.s2.aoi.spatial.as_bbox()
     data.get.download_s2(
         data_dir,
+        config.s2.gee.ee_project_ids,
         bounds,
         config.s2.aoi.temporal.start_date if config.s2.aoi.temporal is not None else None,
         config.s2.aoi.temporal.end_date if config.s2.aoi.temporal is not None else None,
@@ -242,10 +242,10 @@ def download_dynworld(config_path: Path) -> None:
     save_config(config.dynworld, config.data_dir / "dyn_world")
 
     data_dir = Path(config.data_dir)
-    auth(config.dynworld.gee.ee_project_id)
     bounds = config.dynworld.aoi.spatial.as_bbox()
     data.get.download_dynworld(
         data_dir,
+        config.dynworld.gee.ee_project_ids,
         bounds,
         config.dynworld.aoi.temporal.start_date
         if config.dynworld.aoi.temporal is not None
@@ -284,10 +284,10 @@ def download_landsat8(config_path: Path) -> None:
         config.landsat8.selected_bands = satellites.Landsat8().default_selected_bands
     save_config(config.landsat8, config.data_dir / "landsat8")
     data_dir = Path(config.data_dir)
-    auth(config.landsat8.gee.ee_project_id)
     bounds = config.landsat8.aoi.spatial.as_bbox()
     data.get.download_landsat8(
         data_dir,
+        config.landsat8.gee.ee_project_ids,
         bounds,
         config.landsat8.aoi.temporal.start_date
         if config.landsat8.aoi.temporal is not None
@@ -327,10 +327,10 @@ def download_palsar2(config_path: Path) -> None:
         config.palsar2.selected_bands = satellites.Palsar2().default_selected_bands
     save_config(config.palsar2, config.data_dir / "palsar2")
     data_dir = Path(config.data_dir)
-    auth(config.palsar2.gee.ee_project_id)
     bounds = config.palsar2.aoi.spatial.as_bbox()
     data.get.download_palsar2(
         data_dir,
+        config.palsar2.gee.ee_project_ids,
         bounds,
         config.palsar2.aoi.temporal.start_date if config.palsar2.aoi.temporal is not None else None,
         config.palsar2.aoi.temporal.end_date if config.palsar2.aoi.temporal is not None else None,
@@ -370,7 +370,6 @@ def download_nasadem(config_path: Path) -> None:
         config.nasadem.selected_bands = satellites.NASADEM().default_selected_bands
     save_config(config.nasadem, config.data_dir / "nasadem")
     data_dir = Path(config.data_dir)
-    auth(config.nasadem.gee.ee_project_id)
     bounds = config.nasadem.aoi.spatial.as_bbox()
     if config.nasadem.aoi.temporal is not None:
         log.warning(
@@ -379,6 +378,7 @@ def download_nasadem(config_path: Path) -> None:
         )
     data.get.download_nasadem(
         data_dir,
+        config.nasadem.gee.ee_project_ids,
         bounds,
         crs=(
             CRS.from_epsg(config.nasadem.aoi.spatial.epsg)
@@ -414,7 +414,6 @@ def download_custom(config_path: Path, custom_name: str) -> None:
     )
     save_config(custom_config, config.data_dir / satellite_custom.name)
     data_dir = Path(config.data_dir)
-    auth(custom_config.gee.ee_project_id)
     bounds = custom_config.aoi.spatial.as_bbox()
     start_date = (
         custom_config.aoi.temporal.start_date if custom_config.aoi.temporal is not None else None
@@ -426,6 +425,7 @@ def download_custom(config_path: Path, custom_name: str) -> None:
     data.get.download_custom(
         satellite_custom,
         data_dir,
+        custom_config.gee.ee_project_ids,
         bounds,
         start_date,
         end_date,

--- a/src/geefetch/cli/omegaconfig.py
+++ b/src/geefetch/cli/omegaconfig.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -29,8 +29,9 @@ class GEEConfig:
 
     Attributes
     ----------
-    ee_project_id : str
-        Your GEE id, to connect to the API.
+    ee_project_id : str | list[str]
+        One or more GEE project id, to connect to the API. More project ids allow `geefetch`
+        to process downloads in parallel.
 
         .. see also:: https://developers.google.com/earth-engine/apidocs/ee-initialize
     max_tile_size : int
@@ -39,7 +40,7 @@ class GEEConfig:
         Decrease if User Memory Excess Error, but choose highest possible otherwise. Defaults is 10.
     """
 
-    ee_project_id: str = "my-ee-project"
+    ee_project_ids: list[str] = field(default_factory=list)
     max_tile_size: int = 10
 
 
@@ -246,7 +247,16 @@ class NASADEMConfig(SatelliteDefaultConfig):
 
 @dataclass
 class CustomSatelliteConfig(SatelliteDefaultConfig):
-    """The structured type for configuring a custom GEE dataset source."""
+    """The structured type for configuring a custom GEE dataset source.
+
+    Attributes
+    ----------
+    url : str
+        The Google Earth Engine id to access the satellite. Example: "NASA/NASADEM_HGT/001"
+    pixel_range : tuple[float, float]
+        The (min, max) range of pixel values. Used to normalize the custom satellite data.
+
+    """
 
     url: str = "unknown"
     pixel_range: tuple[float, float] = (-1, -1)

--- a/src/geefetch/data/downloadables/geedim.py
+++ b/src/geefetch/data/downloadables/geedim.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import threading
 import traceback
@@ -65,7 +66,8 @@ class PatchedBaseImage(BaseImage):  # type: ignore[misc]
         progress: Progress | None = None,
         **kwargs: Any,
     ) -> None:
-        max_threads = 39
+        max_threads = num_threads or min(10, (os.cpu_count() or 1) + 4)
+        max_threads = 37
         geedim_log.debug(f"Using {max_threads} threads for download.")
         out_lock = threading.Lock()
         filename = Path(filename)

--- a/src/geefetch/utils/enums.py
+++ b/src/geefetch/utils/enums.py
@@ -91,7 +91,7 @@ class S1Orbit(Enum):
 
 
 class P2Orbit(Enum):
-    """The type of Sentinel-1 orbit."""
+    """The type of Palsar-2 orbit."""
 
     ASCENDING = "Ascending"
     DESCENDING = "Descending"

--- a/src/geefetch/utils/gee.py
+++ b/src/geefetch/utils/gee.py
@@ -1,6 +1,25 @@
 """Google Earth Engine utilities."""
 
+from functools import wraps
+
 import ee
+import requests.adapters
+
+__all__ = ["auth"]
+
+# Store original __init__ method
+_original_init = requests.adapters.HTTPAdapter.__init__
+
+
+@wraps(_original_init)
+def patched_init(self, *args, **kwargs):
+    if "pool_maxsize" not in kwargs and len(args) < 2:
+        kwargs["pool_maxsize"] = 40  # your desired default
+    return _original_init(self, *args, **kwargs)
+
+
+# Monkey-patch it globally
+requests.adapters.HTTPAdapter.__init__ = patched_init  # type: ignore[method-assign]
 
 
 def auth(project: str) -> None:

--- a/src/geefetch/utils/log_multiprocessing.py
+++ b/src/geefetch/utils/log_multiprocessing.py
@@ -1,0 +1,133 @@
+"""
+Multiprocessing-safe logging via a shared queue.
+
+This module patches the Python logging system so that child processes can
+forward log records to the main process. Workers emit logs as usual with
+`logging.getLogger(...).info(...)`; the patch redirects them into a
+multiprocessing queue. The parent process consumes the queue and replays
+the messages through its own logging handlers.
+
+
+Example
+-------
+>>> import multiprocessing as mp
+>>> import logging
+>>> from utils import LogQueueConsumer, init_log_queue_for_children
+>>>
+>>> logging.basicConfig(level=logging.INFO)
+>>> log_queue = mp.Manager().Queue()
+>>>
+>>> def worker(x):
+...     log = logging.getLogger(__name__)
+...     log.info("processing %s", x)
+...     return x * 2
+>>>
+>>> with LogQueueConsumer(log_queue), mp.Pool(
+...     processes=2,
+...     initializer=init_log_queue_for_children,
+...     initargs=(log_queue,)
+... ) as pool:
+...     results = pool.map(worker, range(4))
+>>> print(results)
+[0, 2, 4, 6]
+"""
+
+import logging
+import threading
+import time
+from multiprocessing.queues import Queue
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+if TYPE_CHECKING:
+    LogQueue: TypeAlias = Queue[tuple[str, int, str]]  # logger name, level, message
+else:
+    LogQueue: TypeAlias = Queue
+
+# Global queue (set by init in child processes)
+log_queue: LogQueue | None = None
+
+
+class QueueLogger(logging.Logger):
+    """
+    A Logger subclass that forwards log messages to a multiprocessing queue
+    if one is configured, otherwise falls back to normal logging.
+
+    Intended for multiprocessing use: children push logs into the queue,
+    the parent consumes and replays them.
+    """
+
+    def _log_to_queue_or_local(self, level: int, msg: str, *args: Any, **kwargs: Any) -> None:
+        if log_queue is not None:
+            log_queue.put((self.name, level, msg % args if args else msg))
+        else:
+            super().log(level, msg, *args, **kwargs)
+
+    # Override the standard log methods
+    def debug(self, msg: str, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
+        self._log_to_queue_or_local(logging.DEBUG, msg, *args, **kwargs)
+
+    def info(self, msg: str, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
+        self._log_to_queue_or_local(logging.INFO, msg, *args, **kwargs)
+
+    def warning(self, msg: str, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
+        self._log_to_queue_or_local(logging.WARNING, msg, *args, **kwargs)
+
+    def error(self, msg: str, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
+        self._log_to_queue_or_local(logging.ERROR, msg, *args, **kwargs)
+
+    def critical(self, msg: str, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
+        self._log_to_queue_or_local(logging.CRITICAL, msg, *args, **kwargs)
+
+
+def init_log_queue_for_children(queue: LogQueue) -> None:
+    """
+    Multiprocessing initializer: configure all future loggers to use QueueLogger
+    and set the global log_queue for forwarding.
+    """
+    global log_queue
+    log_queue = queue
+    logging.setLoggerClass(QueueLogger)  # patch the logger class
+
+
+class LogQueueConsumer:
+    """
+    Context manager that consumes log records from a multiprocessing queue
+    in a background thread and replays them locally.
+    """
+
+    def __init__(self, queue: LogQueue, interval: float = 0.5):
+        self.queue = queue
+        self.interval = interval
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self):
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        self._drain()
+
+        # Only close if supported (i.e. non-manager queues)
+        if hasattr(self.queue, "close"):
+            self.queue.close()
+        if hasattr(self.queue, "join_thread"):
+            self.queue.join_thread()
+        return False
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            self._drain()
+            time.sleep(self.interval)
+
+    def _drain(self) -> None:
+        while not self.queue.empty():
+            try:
+                logger_name, level, msg = self.queue.get_nowait()
+                logging.getLogger(logger_name).log(level, msg)
+            except Exception:
+                break


### PR DESCRIPTION
The goal for this PR is to implement a built-in process parallelism so that we can specify

```
ee_project_ids = [id1, id2, id3, id4]
```

and let `geefetch` handle parallelism and spread of work between processes.